### PR TITLE
Fixing a crash when the parentCommit is nil.

### DIFF
--- a/Xit/XTCommitHeaderViewController.m
+++ b/Xit/XTCommitHeaderViewController.m
@@ -154,7 +154,9 @@ dragDestinationActionMaskForDraggingInfo:(id<NSDraggingInfo>)draggingInfo
         [gtRepo lookupObjectBySHA:parentSHA error:&error];
     
     if (parentCommit == nil) {
-      NSLog(@"%@", error);
+      if ([parentSHA length] > 0) {
+        NSLog(@"%@", error);
+      }
       continue;
     }
 


### PR DESCRIPTION
This happened for me, when I clicked the first commit in a repo. The parentSHA was an empty string. We probably should handle the error in some way instead of just logging it.

Additionally, Apple guidelines say that you are not supposed to check the error value for anything. Just use it after you know there was a problem, because a method returned `NO` for success or `nil`.
