### PR TITLE
Added unversioned TeamID infrastructure.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ build/
 
 xcuserdata
 DerivedData
+
+# User-specific xcconfig files
+Xcode-config/DEVELOPMENT_TEAM.xcconfig

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,13 @@ The repository uses several submodules, so you will need to clone the repository
 
 Note that Objective Git needs the `objective-git/script/bootstrap` script to be run to configure everything. If Objective Git is later updated, you may need to re-run the script.
 
+**IMPORTANT:** If you do not have an Apple ID with a developer account for code signing Mac apps, the build  will fail with a code signing error. To work around this, you can delete the "Code Signing Identity" build setting of the "Application" target to work around the issue.
+
+**Alternatively**, if you do have a developer account, you can create the file "Xcode-config/DEVELOPMENT_TEAM.xcconfig" with the following build setting as its content:
+> DEVELOPMENT_TEAM = [Your TeamID]
+
+For a more detailed description of this, you can have a look at the comments within the file "Xcode-config/Shared.xcconfig". 
+
 ## Finding tasks
 
 If you're looking for a starter task, several issues have been marked "good first issue". These should provide a relatively easy intro to the code base.

--- a/Xcode-config/Shared.xcconfig
+++ b/Xcode-config/Shared.xcconfig
@@ -1,0 +1,38 @@
+#include "DEVELOPMENT_TEAM.xcconfig"
+
+// Create the file DEVELOPMENT_TEAM.xcconfig
+// in the "Xcode-config" directory within the project directory
+// with the following build setting:
+// DEVELOPMENT_TEAM = [Your TeamID]
+
+// Hint: recent Xcode versions appear to automatically create an empty file 
+// for you on the first build. This build will fail, or course, 
+// because code-signing can’t work without the DEVELOPMENT_TEAM set. 
+// Just fill it in and everything should work. 
+
+// You can find your team ID by logging into your Apple Developer account
+// and going to
+// https://developer.apple.com/account/#/membership
+// It should be listed under “Team ID”.
+
+// To set this system up for your own project,
+// copy the "Xcode-config" directory there,
+// add it to your Xcode project,
+// navigate to your project settings
+// (root icon in the Xcode Project Navigator)
+// click on the project icon there,
+// click on the “Info” tab
+// under “Configurations”
+// open the “Debug”, “Release”,
+// and any other build configurations you might have.
+// There you can set the pull-down menus in the
+// “Based on Configuration File” column to “Shared”.
+// Done.
+
+// Don’t forget to add the DEVELOPMENT_TEAM.xcconfig file to your .gitignore:
+// # User-specific xcconfig files
+// Xcode-config/DEVELOPMENT_TEAM.xcconfig
+
+// You can now remove the “DevelopmentTeam = AB1234C5DE;” entries from the
+// .xcodeproj/project.pbxproj if you want to.
+

--- a/Xcode-config/Shared.xcconfig
+++ b/Xcode-config/Shared.xcconfig
@@ -10,7 +10,34 @@
 // because code-signing can’t work without the DEVELOPMENT_TEAM set. 
 // Just fill it in and everything should work. 
 
-// You can find your team ID by logging into your Apple Developer account
+// The following is based on https://stackoverflow.com/a/47732584:
+// Set up “Accounts” in Xcode’s preferences with the Apple ID you want to use for development.
+// On macOS, you can then find your personal team ID in the keychain.
+// Your developer and distribution certificates have your Team ID in them.
+// To access your keychain, open the “Keychain Access” app:
+// /Applications/Utilities/Keychain Access
+
+// Under the ’login’ Keychain, go into the ‘Certificates’ category.
+// Scroll or search to find your development or distribution certificate.
+// The names of the certificates follows a pattern:
+// Certificate Type Name: Team Name (certificate ID)
+// where the “Certificate Type Name” is something like:
+// Developer ID Installer
+// Developer ID Application
+// 3rd Party Mac Developer Installer
+// 3rd Party Mac Developer Application
+// iPhone Distribution
+// iPhone Developer
+
+// Double-click on the certificate, and the
+// “Organizational Unit”
+// is the “Team ID” you are looking for.
+
+// Note that this is the only way to find your
+// "Personal team" ID
+// You can’t find the "Personal team" ID aynwhere on Apple’s website.
+
+// You can also find your generic team ID by logging into your Apple Developer account
 // and going to
 // https://developer.apple.com/account/#/membership
 // It should be listed under “Team ID”.

--- a/Xit.xcodeproj/project.pbxproj
+++ b/Xit.xcodeproj/project.pbxproj
@@ -419,6 +419,8 @@
 		31355B0713EA139700C33AAB /* CoreFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreFoundation.framework; path = System/Library/Frameworks/CoreFoundation.framework; sourceTree = SDKROOT; };
 		31A8939F13E9DA5B008BE0C2 /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
 		31C7C13213ECC74C00A65FE9 /* HistoryViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = HistoryViewController.xib; sourceTree = "<group>"; };
+		3DB98C8323E0928A0039B454 /* DEVELOPMENT_TEAM.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = DEVELOPMENT_TEAM.xcconfig; sourceTree = "<group>"; };
+		3DB98C8423E0928A0039B454 /* Shared.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Shared.xcconfig; sourceTree = "<group>"; };
 		89039F551703A9FC000949A8 /* html */ = {isa = PBXFileReference; lastKnownFileType = folder; path = html; sourceTree = "<group>"; };
 		891261AF1F867FCC00C292B7 /* GitTree.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GitTree.swift; sourceTree = "<group>"; };
 		89369A721EDF47FC001B69C6 /* NSTask+Throwing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSTask+Throwing.h"; sourceTree = "<group>"; };
@@ -772,9 +774,19 @@
 			path = HistoryView;
 			sourceTree = "<group>";
 		};
+		3DB98C8223E0928A0039B454 /* Xcode-config */ = {
+			isa = PBXGroup;
+			children = (
+				3DB98C8323E0928A0039B454 /* DEVELOPMENT_TEAM.xcconfig */,
+				3DB98C8423E0928A0039B454 /* Shared.xcconfig */,
+			);
+			path = "Xcode-config";
+			sourceTree = "<group>";
+		};
 		C3FA46F113D0F8E200AC4F9B = {
 			isa = PBXGroup;
 			children = (
+				3DB98C8223E0928A0039B454 /* Xcode-config */,
 				DD96C98F176976FC0003A30C /* ObjectiveGitFramework.xcodeproj */,
 				C91F34631D30647D005F9BDF /* Siesta.xcodeproj */,
 				C954C169237C6E56000D5339 /* git */,
@@ -1764,6 +1776,7 @@
 /* Begin XCBuildConfiguration section */
 		C3D6CF2513D4DEE300D35D4D /* coverage */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3DB98C8423E0928A0039B454 /* Shared.xcconfig */;
 			buildSettings = {
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
@@ -1886,6 +1899,7 @@
 		};
 		C3FA472F13D0F8E300AC4F9B /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3DB98C8423E0928A0039B454 /* Shared.xcconfig */;
 			buildSettings = {
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
@@ -1935,6 +1949,7 @@
 		};
 		C3FA473013D0F8E300AC4F9B /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3DB98C8423E0928A0039B454 /* Shared.xcconfig */;
 			buildSettings = {
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;


### PR DESCRIPTION
This PR makes it possible for multiple developers to build Xit out of the box. All everyone has to do once is to create a file called "DEVELOPMENT_TEAM.xcconfig" in the "Xcode-config" directory within the project directory with the following build setting:
DEVELOPMENT_TEAM = [personal TeamID]

The file is excluded from versioning.

Please give it a go.
