### PR TITLE
Re ordered `LIBRARY_SEARCH_PATHS`

### DIFF
--- a/Xit.xcodeproj/project.pbxproj
+++ b/Xit.xcodeproj/project.pbxproj
@@ -1918,8 +1918,8 @@
 				);
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
-					/usr/local/lib,
 					/opt/homebrew/lib,
+					/usr/local/lib,
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				ONLY_ACTIVE_ARCH = YES;
@@ -2051,8 +2051,8 @@
 				);
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
-					/usr/local/lib,
 					/opt/homebrew/lib,
+					/usr/local/lib,
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				ONLY_ACTIVE_ARCH = YES;
@@ -2104,8 +2104,8 @@
 				);
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
-					/usr/local/lib,
 					/opt/homebrew/lib,
+					/usr/local/lib,
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				ONLY_ACTIVE_ARCH = YES;


### PR DESCRIPTION
So Homebrew path is checked first, so migrated Homebrew setups don’t look in the older path first.